### PR TITLE
Refresh dependency policy and CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
       - name: 📥 Get latest code
         uses: actions/checkout@v5
 
+      - name: 📦 Install pnpm
+        uses: pnpm/action-setup@v5
+
       - name: 🔧 Set up Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-
-      - name: 📦 Install pnpm
-        uses: pnpm/action-setup@v5
 
       - name: 💾 Cache pnpm store
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: 📥 Get latest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
       - name: 📦 Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: 💾 Cache pnpm store
         uses: actions/cache@v4

--- a/.github/workflows/daily-reservation.yml
+++ b/.github/workflows/daily-reservation.yml
@@ -30,15 +30,15 @@ jobs:
 
     steps:
       - name: 📥 Get latest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
       - name: 📦 Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 11.1.3
 

--- a/.github/workflows/daily-reservation.yml
+++ b/.github/workflows/daily-reservation.yml
@@ -32,15 +32,15 @@ jobs:
       - name: 📥 Get latest code
         uses: actions/checkout@v5
 
-      - name: 🔧 Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '24'
-
       - name: 📦 Install pnpm
         uses: pnpm/action-setup@v5
         with:
           version: 11.1.3
+
+      - name: 🔧 Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
 
       - name: 💾 Cache pnpm store
         uses: actions/cache@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,5 +12,5 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@v5
+      - uses: actions/dependency-review-action@v5

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 1440
+
 allowBuilds:
   esbuild: true
   puppeteer: true


### PR DESCRIPTION
## Summary
- Add pnpm `minimumReleaseAge` to `pnpm-workspace.yaml`
- Remove redundant `.npmrc` minimum-release-age config
- Move remaining workflow Actions to v5
- Install pnpm before `setup-node@v5` so setup-node can resolve pnpm cache support

## Validation
- Parsed edited YAML files with Ruby Psych
- Ran `git diff --check`