### PR TITLE
[codex] Add weekly booking schedule mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,15 @@ TWO_CAPTCHA_API_KEY=your-2captcha-api-key
 # How many days ahead to book (default: 7 if not set)
 AVAILABLE_DAYS=7
 
+# How often the scheduled workflow should actually book.
+# Use "daily" for the default behaviour, or "weekly" for gyms that open
+# the whole week at once.
+BOOKING_FREQUENCY=daily
+
+# Used only when BOOKING_FREQUENCY=weekly.
+# Valid values: monday, tuesday, wednesday, thursday, friday, saturday, sunday
+BOOKING_WEEKDAY=sunday
+
 # Your preferred time per day in 24-hour format (e.g. 18:00).
 # Only add the days you want to book — leave the rest out.
 # For multiple classes at the same time, append the class name: 18:00|CrossFit

--- a/.github/workflows/daily-reservation.yml
+++ b/.github/workflows/daily-reservation.yml
@@ -32,17 +32,55 @@ jobs:
       - name: 📥 Get latest code
         uses: actions/checkout@v5
 
+      - name: 🗓️ Decide whether to run today
+        id: schedule-gate
+        env:
+          BOOKING_FREQUENCY: ${{ vars.BOOKING_FREQUENCY || 'daily' }}
+          BOOKING_WEEKDAY: ${{ vars.BOOKING_WEEKDAY || 'sunday' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          frequency="$(echo "${BOOKING_FREQUENCY:-daily}" | tr '[:upper:]' '[:lower:]' | xargs)"
+          target_day="$(echo "${BOOKING_WEEKDAY:-sunday}" | tr '[:upper:]' '[:lower:]' | xargs)"
+          today="$(TZ=Europe/Madrid date +%A | tr '[:upper:]' '[:lower:]')"
+
+          case "$target_day" in
+            monday|tuesday|wednesday|thursday|friday|saturday|sunday) ;;
+            *)
+              echo "Unknown BOOKING_WEEKDAY '$BOOKING_WEEKDAY'; defaulting to daily."
+              echo "Unknown BOOKING_WEEKDAY '$BOOKING_WEEKDAY'; defaulted to daily for this run." >> "$GITHUB_STEP_SUMMARY"
+              frequency="daily"
+              ;;
+          esac
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Manual run requested — booking script will run." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$frequency" = "weekly" ] && [ "$today" != "$target_day" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "Weekly mode is enabled for $target_day. Today is $today in Europe/Madrid, so AutoWOD skipped this scheduled run." >> "$GITHUB_STEP_SUMMARY"
+          else
+            if [ "$frequency" != "daily" ] && [ "$frequency" != "weekly" ]; then
+              echo "Unknown BOOKING_FREQUENCY '$BOOKING_FREQUENCY'; defaulting to daily."
+              echo "Unknown BOOKING_FREQUENCY '$BOOKING_FREQUENCY'; defaulted to daily for this run." >> "$GITHUB_STEP_SUMMARY"
+            fi
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "AutoWOD will run today ($today, Europe/Madrid)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: 📦 Install pnpm
+        if: steps.schedule-gate.outputs.should_run == 'true'
         uses: pnpm/action-setup@v5
         with:
           version: 11.1.3
 
       - name: 🔧 Set up Node.js
+        if: steps.schedule-gate.outputs.should_run == 'true'
         uses: actions/setup-node@v5
         with:
           node-version: '24'
 
       - name: 💾 Cache pnpm store
+        if: steps.schedule-gate.outputs.should_run == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
@@ -51,9 +89,11 @@ jobs:
             pnpm-store-${{ runner.os }}-
 
       - name: 📚 Install dependencies
+        if: steps.schedule-gate.outputs.should_run == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: 💾 Cache Puppeteer browser
+        if: steps.schedule-gate.outputs.should_run == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.cache/puppeteer
@@ -62,9 +102,11 @@ jobs:
             puppeteer-cache-${{ runner.os }}-
 
       - name: 🌐 Install Chrome for Puppeteer
+        if: steps.schedule-gate.outputs.should_run == 'true'
         run: pnpm exec puppeteer browsers install chrome
 
       - name: 📋 Restore booking state
+        if: steps.schedule-gate.outputs.should_run == 'true'
         id: booking-state-restore
         uses: actions/cache/restore@v4
         with:
@@ -74,6 +116,7 @@ jobs:
             booking-state-${{ runner.os }}-
 
       - name: 🎯 Run booking script
+        if: steps.schedule-gate.outputs.should_run == 'true'
         env:
           # Secrets (sensitive — set in Settings → Secrets and variables → Actions → Secrets tab)
           EMAIL: ${{ secrets.EMAIL }}
@@ -92,7 +135,7 @@ jobs:
         run: pnpm start
 
       - name: 💾 Save booking state
-        if: always()
+        if: ${{ always() && steps.schedule-gate.outputs.should_run == 'true' }}
         uses: actions/cache/save@v4
         with:
           path: booking-state.json

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ TUESDAY=18:00|Endurance
 | Name | Value | Meaning |
 |------|-------|---------|
 | `AVAILABLE_DAYS` | `7` | Book up to 7 days in advance (default if not set) |
+| `BOOKING_FREQUENCY` | `daily` | Use `daily` to try every day, or `weekly` to book only once per week |
+| `BOOKING_WEEKDAY` | `sunday` | Used with `BOOKING_FREQUENCY=weekly`; choose `monday` through `sunday` |
 
 ### 4. Get a 2Captcha API key
 
@@ -85,7 +87,7 @@ The tool needs this to handle the login security check automatically.
 1. Click the **Actions** tab in your forked repository
 2. If prompted, click **I understand my workflows, go ahead and enable them**
 
-That's it! The tool will now run automatically every evening around 22:30 Spain time.
+That's it! By default, the tool will now run automatically every evening around 22:30 Spain time.
 
 ---
 
@@ -107,14 +109,24 @@ Go to **Settings → Secrets and variables → Actions → Variables tab**, clic
 
 ## My gym opens all reservations on one day
 
-Some gyms release the full week's schedule at once (e.g. every Sunday). Instead of running daily, you can trigger the tool manually:
+Some gyms release the full week's schedule at once (e.g. every Sunday). In that case, set these repository variables:
+
+| Name | Value example |
+|------|---------------|
+| `BOOKING_FREQUENCY` | `weekly` |
+| `BOOKING_WEEKDAY` | `sunday` |
+| `AVAILABLE_DAYS` | `7` |
+
+The workflow still wakes up every day because GitHub Actions schedules cannot be changed by repository variables, but AutoWOD will skip immediately on the other days before installing dependencies or solving any CAPTCHA.
+
+You can also trigger the tool manually whenever you need:
 
 1. Go to **Actions → Daily Reservation**
 2. Click **Run workflow** (top right)
 3. In the *Days to book ahead* field, enter the number of days you want to cover (e.g. `7`)
 4. Click **Run workflow**
 
-This books everything in one go.
+Manual runs always run immediately, even when `BOOKING_FREQUENCY=weekly`.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a weekly booking mode for gyms that open the full schedule on a single day.

- Adds a workflow gate controlled by `BOOKING_FREQUENCY` and `BOOKING_WEEKDAY`
- Skips scheduled runs before dependency install/CAPTCHA work when weekly mode is enabled for another day
- Keeps manual `workflow_dispatch` runs available as immediate one-off overrides
- Documents the new repository variables in the README and `.env.example`

## Validation

- Parsed `.github/workflows/daily-reservation.yml` with Ruby YAML loader
- Ran `git diff --check`
- Ran `CI=true pnpm test` successfully: 28 tests passed