### PR TITLE
chore: scope vitest to src (fix stale dist test failures)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Only run TypeScript sources; ignore compiled output in dist/.
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Fixes the pre-existing baseline test failures noted during the CVE sweep.

`vitest run` was collecting compiled `dist/__tests__/*.test.js` (CommonJS) alongside the real `src/__tests__/*.test.ts`, and the compiled files fail under ESM (`Vitest cannot be imported in a CommonJS module using require()`). Added `vitest.config.ts` restricting collection to `src/**/*.test.ts`.

**Validation**: `pnpm test` → 2 files, 28 tests pass (no dist pickup); lint and typecheck pass.

https://claude.ai/code/session_01P922wsRoNP5BwhCirmJU1P