### PR TITLE
fix: stop booking loop at the gym's reservation horizon

### DIFF
--- a/src/services/reservation.ts
+++ b/src/services/reservation.ts
@@ -268,8 +268,19 @@ export async function processReservations(
       other++;
     }
 
-    const isLastDay = i === availableDays - 1;
-    if (!isLastDay) await goToNextDay(page);
+    if (i === availableDays - 1) break;
+
+    // The gym only opens reservations a few days ahead. Past that horizon the
+    // calendar's "next" control no longer advances the date, so stop instead
+    // of re-processing — and re-booking — the same last day.
+    const dateBefore = getISODateFromUrl(page);
+    await goToNextDay(page);
+    if (getISODateFromUrl(page) === dateBefore) {
+      console.log(
+        `📆 ${dateBefore} is the last bookable day for now — stopping.`
+      );
+      break;
+    }
   }
 
   console.log(


### PR DESCRIPTION
## Problem
`processReservations` loops `AVAILABLE_DAYS` (default 7) times, advancing the calendar each iteration. The gym only opens reservations a few days ahead. Past that horizon the calendar's "next" control no longer advances the date, so the loop re-processed the same last day repeatedly — e.g. in a recent run Wednesday 01/07 was "booked" 5 times.

## Fix
Capture the date before `goToNextDay`; if it's unchanged afterward, we've hit the bookable horizon, so break. Self-adjusts to whatever window the gym uses; `AVAILABLE_DAYS` stays the upper bound.

## Notes
- The gym deduped the repeat bookings server-side (verified in the WODBuster app — only one booking persisted), so this is a correctness/clarity fix, not a double-booking bug.
- The browser-driving loop isn't unit-tested (existing suite covers pure helpers only); typecheck, lint, and 28 tests pass.

https://claude.ai/code/session_011GBX2b9iGgcByiFVuasuTD